### PR TITLE
Dimacs-like formula input support, various changes

### DIFF
--- a/backend/docs/ClauseSet.md
+++ b/backend/docs/ClauseSet.md
@@ -16,7 +16,7 @@ A single trailing `;` or line break at the end of the formula will be removed.
 ### Atoms
 
 An atom, a propositional variable that may or may not be negated,
-is represented by the variable name (strictly latin characters, lower or upper case).
+is represented by the variable name (strictly alphanumerical characters, lower or upper case).
 Optionally preceeded by a `!` to indicate negation.
 
 ### Clauses

--- a/backend/src/main/kotlin/kalkulierbar/clause/Atom.kt
+++ b/backend/src/main/kotlin/kalkulierbar/clause/Atom.kt
@@ -4,19 +4,14 @@ import kalkulierbar.logic.SyntacticEquality
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Atom<AtomType>(val lit: AtomType, val negated: Boolean = false) {
+data class Atom<AtomType>(val lit: AtomType, val negated: Boolean = false) : SyntacticEquality {
     operator fun not() = Atom(lit, !negated)
 
     override fun toString(): String {
         return if (negated) "!$lit" else lit.toString()
     }
 
-    /**
-     * Override equality to match syntactic equality intuition
-     * @param other Atom to compare against
-     * @return true iff the two atoms are syntactically equal
-     */
-    override fun equals(other: Any?): Boolean {
+    override fun synEq(other: Any?): Boolean {
         var eq = false
 
         if (other is Atom<*> && other.negated == negated) {
@@ -29,6 +24,21 @@ data class Atom<AtomType>(val lit: AtomType, val negated: Boolean = false) {
 
         return eq
     }
+
+    override fun clone(): Atom<AtomType> {
+        return if (lit is SyntacticEquality)
+            @Suppress("UNCHECKED_CAST")
+            Atom(lit.clone() as AtomType, negated)
+        else
+            Atom(lit, negated)
+    }
+
+    /**
+     * Override equality to match syntactic equality intuition
+     * @param other Atom to compare against
+     * @return true iff the two atoms are syntactically equal
+     */
+    override fun equals(other: Any?) = synEq(other)
 
     override fun hashCode() = lit.toString().hashCode() + negated.toString().hashCode()
 }

--- a/backend/src/main/kotlin/kalkulierbar/clause/Clause.kt
+++ b/backend/src/main/kotlin/kalkulierbar/clause/Clause.kt
@@ -12,11 +12,10 @@ class Clause<AtomType>(var atoms: MutableList<Atom<AtomType>> = mutableListOf())
         c.forEach { add(it) }
     }
 
-    // TODO: Properly clone atoms
     fun clone(): Clause<AtomType> {
         val newClause = Clause<AtomType>()
         for (c in atoms) {
-            newClause.add(c.copy())
+            newClause.add(c.clone())
         }
         return newClause
     }

--- a/backend/src/main/kotlin/kalkulierbar/logic/FirstOrderTerm.kt
+++ b/backend/src/main/kotlin/kalkulierbar/logic/FirstOrderTerm.kt
@@ -23,7 +23,10 @@ abstract class FirstOrderTerm : SyntacticEquality {
      * Create a deep copy of a term
      * @return copy of the current term
      */
-    abstract fun clone(qm: Map<String, Quantifier> = mapOf()): FirstOrderTerm
+    abstract fun clone(qm: Map<String, Quantifier>): FirstOrderTerm
+
+    // Implement simple clone function required by SynEq
+    override fun clone() = clone(mapOf())
 }
 
 @Serializable

--- a/backend/src/main/kotlin/kalkulierbar/logic/LogicNodes.kt
+++ b/backend/src/main/kotlin/kalkulierbar/logic/LogicNodes.kt
@@ -81,6 +81,9 @@ class Relation(val spelling: String, var arguments: List<FirstOrderTerm>) : Synt
         return Relation(spelling, args)
     }
 
+    // Implement simple clone function required by SynEq
+    override fun clone() = clone(mapOf())
+
     override fun <ReturnType> accept(visitor: LogicNodeVisitor<ReturnType>) = visitor.visit(this)
 
     /**

--- a/backend/src/main/kotlin/kalkulierbar/logic/abstractLogic.kt
+++ b/backend/src/main/kotlin/kalkulierbar/logic/abstractLogic.kt
@@ -66,4 +66,10 @@ interface SyntacticEquality {
      * @return true iff the terms are equal
      */
     fun synEq(other: Any?): Boolean
+
+    /**
+     * Create a deep copy of the object
+     * @return copy of the current object
+     */
+    fun clone(): SyntacticEquality
 }

--- a/backend/src/main/kotlin/kalkulierbar/logic/transform/UniqueVariables.kt
+++ b/backend/src/main/kotlin/kalkulierbar/logic/transform/UniqueVariables.kt
@@ -112,7 +112,10 @@ class UniqueVariables : DoNothingVisitor() {
  * @param replacementMap Map of all variables to replace and their new variable name
  * @param strict Set to false to allow variables with no associated replacement
  */
-class VariableRenamer(val replacementMap: Map<QuantifiedVariable, String>, val strict: Boolean = true) : FirstOrderTermVisitor<Unit>() {
+class VariableRenamer(
+    val replacementMap: Map<QuantifiedVariable, String>,
+    val strict: Boolean = true
+) : FirstOrderTermVisitor<Unit>() {
 
     /**
      * Change the variable name to the new spelling

--- a/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
@@ -11,7 +11,7 @@ class ClauseSetParser {
 
         /**
          * Parses a set of clauses from text into a ClauseSet using default clause and atom separators
-         * @param formula set of clauses of logical variables, format: a,b;!b,c;d,!e,!f where variables are [a-zA-Z]+
+         * @param formula set of clauses of logical variables, format: a,b;!b,c;d,!e,!f where variables are [a-zA-Z0-9]+
          * @return ClauseSet representing the input formula
          */
         fun parse(formula: String) = parseGeneric(formula, ";", ",", '!')

--- a/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
@@ -14,30 +14,39 @@ class ClauseSetParser {
          * @param formula set of clauses of logical variables, format: a,b;!b,c;d,!e,!f where variables are [a-zA-Z]+
          * @return ClauseSet representing the input formula
          */
-        fun parse(formula: String) = parseGeneric(formula, ";", ",")
+        fun parse(formula: String) = parseGeneric(formula, ";", ",", "!")
 
         /**
          * Parses a set of clauses from text into a ClauseSet with flexible separators
          * @param formula set of clauses of logical variables in textual form
          * @param clauseSeparator string separating clauses from each other, e.g. ";"
          * @param atomSeparator string separating atoms (variables) from each other, e.g. ","
+         * @param negSign string indicating a negated atom
          * @return ClauseSet representing the input formula
          */
-        fun parseGeneric(formula: String, clauseSeparator: String, atomSeparator: String): ClauseSet<String> {
+        fun parseGeneric(
+            formula: String,
+            clauseSeparator: String,
+            atomSeparator: String,
+            negSign: String
+        ): ClauseSet<String> {
+
+            val aSep = Regex.escape(atomSeparator)
+            val cSep = Regex.escape(clauseSeparator)
+            val nSig = Regex.escape(negSign)
 
             // Preprocessing: Remove whitespace & newlines
-            var pf = formula.replace("\n", clauseSeparator).replace(Regex("\\s"), "").replace(Regex(";$"), "")
+            var pf = formula.replace("\n", clauseSeparator).replace(Regex("\\s"), "").replace(Regex("$cSep$"), "")
 
             // Yes, I know, regex
             // The code could technically deal with weirder variable names, but let's keep things simple here
             // This explanation uses the default separators "," and ";"
-            // (!)?[a-zA-Z]+ matches a single variable that may be negated, let's abbreviate that with "v"
+            // (!)?[a-zA-Z0-9]+ matches a single variable that may be negated, let's abbreviate that with "v"
             // v(,v)* matches arbitrarily long lists of variables, e.g. a,b,!c,d. Let's call that "l"
             // l(;l)* matches arbitrarily many lists, e.g. a,b;c,!d;e
             // Easy, right?
-            val aSep = Regex.escape(atomSeparator)
-            val cSep = Regex.escape(clauseSeparator)
-            val formulaFormat = "(!)?[a-zA-Z]+($aSep(!)?[a-zA-Z]+)*($cSep(!)?[a-zA-Z]+($aSep(!)?[a-zA-Z]+)*)*"
+            val atom = "($nSig)?[a-zA-Z0-9]+"
+            val formulaFormat = "$atom($aSep$atom)*($cSep$atom($aSep$atom)*)*"
 
             if (!(Regex(formulaFormat) matches pf))
                 throw InvalidFormulaFormat("Please use alphanumeric variables only, " +

--- a/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
@@ -26,7 +26,7 @@ class ClauseSetParser {
         fun parseGeneric(formula: String, clauseSeparator: String, atomSeparator: String): ClauseSet<String> {
 
             // Preprocessing: Remove whitespace & newlines
-            var processedFormula = formula.replace("\n", clauseSeparator).replace(Regex("\\s"), "").replace(Regex(";$"), "")
+            var pf = formula.replace("\n", clauseSeparator).replace(Regex("\\s"), "").replace(Regex(";$"), "")
 
             // Yes, I know, regex
             // The code could technically deal with weirder variable names, but let's keep things simple here
@@ -39,12 +39,12 @@ class ClauseSetParser {
             val cSep = Regex.escape(clauseSeparator)
             val formulaFormat = "(!)?[a-zA-Z]+($aSep(!)?[a-zA-Z]+)*($cSep(!)?[a-zA-Z]+($aSep(!)?[a-zA-Z]+)*)*"
 
-            if (!(Regex(formulaFormat) matches processedFormula))
+            if (!(Regex(formulaFormat) matches pf))
                 throw InvalidFormulaFormat("Please use alphanumeric variables only, " +
                     "separate atoms with '$atomSeparator' and clauses with '$clauseSeparator'.")
 
             val parsed = ClauseSet<String>()
-            val clauses = processedFormula.split(clauseSeparator)
+            val clauses = pf.split(clauseSeparator)
 
             for (clause in clauses) {
                 val members = clause.split(atomSeparator)

--- a/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/ClauseSetParser.kt
@@ -14,26 +14,26 @@ class ClauseSetParser {
          * @param formula set of clauses of logical variables, format: a,b;!b,c;d,!e,!f where variables are [a-zA-Z]+
          * @return ClauseSet representing the input formula
          */
-        fun parse(formula: String) = parseGeneric(formula, ";", ",", "!")
+        fun parse(formula: String) = parseGeneric(formula, ";", ",", '!')
 
         /**
          * Parses a set of clauses from text into a ClauseSet with flexible separators
          * @param formula set of clauses of logical variables in textual form
          * @param clauseSeparator string separating clauses from each other, e.g. ";"
          * @param atomSeparator string separating atoms (variables) from each other, e.g. ","
-         * @param negSign string indicating a negated atom
+         * @param negSign char indicating a negated atom
          * @return ClauseSet representing the input formula
          */
         fun parseGeneric(
             formula: String,
             clauseSeparator: String,
             atomSeparator: String,
-            negSign: String
+            negSign: Char
         ): ClauseSet<String> {
 
             val aSep = Regex.escape(atomSeparator)
             val cSep = Regex.escape(clauseSeparator)
-            val nSig = Regex.escape(negSign)
+            val nSig = Regex.escape(negSign.toString())
 
             // Preprocessing: Remove whitespace & newlines
             var pf = formula.replace("\n", clauseSeparator).replace(Regex("\\s"), "").replace(Regex("$cSep$"), "")
@@ -64,7 +64,7 @@ class ClauseSetParser {
                     // true -> positive variable / false -> negated variable
                     val atom: Atom<String>
 
-                    if (member[0] == '!')
+                    if (member[0] == negSign)
                         atom = Atom(member.substring(1), true)
                     else
                         atom = Atom(member)

--- a/backend/src/main/kotlin/kalkulierbar/parsers/DimacsLikeParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/DimacsLikeParser.kt
@@ -1,0 +1,17 @@
+package kalkulierbar.parsers
+
+import kalkulierbar.clause.ClauseSet
+
+object DimacsLikeParser {
+
+    /**
+     * Parses a set of clauses from text into a ClauseSet using dimacs-like separators
+     * @param formula set of clauses of logical variables, format: a b 0 -b c 0 d -e -f where variables are [a-zA-Z0-9]+
+     * @return ClauseSet representing the input formula
+     */
+    fun parse(formula: String): ClauseSet<String> {
+        // Preprocessing: Replace whitespace with break markers, remove linebreaks, replace clause end markers
+        val pf = formula.replace("\n", "").replace(Regex("( )?\\b0\\b( )?"), ";").replace(Regex("\\s+"), ",")
+        return ClauseSetParser.parseGeneric(pf, ";", ",", '-')
+    }
+}

--- a/backend/src/main/kotlin/kalkulierbar/parsers/FlexibleClauseSetParser.kt
+++ b/backend/src/main/kotlin/kalkulierbar/parsers/FlexibleClauseSetParser.kt
@@ -7,82 +7,85 @@ import kalkulierbar.logic.LogicNode
 import kalkulierbar.logic.transform.NaiveCNF
 import kalkulierbar.logic.transform.TseytinCNF
 
-class FlexibleClauseSetParser {
+object FlexibleClauseSetParser {
 
-    companion object Companion {
+    /**
+     * Parses a clause set or a propositional formula into a ClauseSet
+     * For format specifications, see ClauseSetParser and PropositionalParser
+     * @param formula formula or clause set to parse
+     * @return ClauseSet representing the input formula
+     */
+    @Suppress("ReturnCount")
+    fun parse(formula: String, strategy: CnfStrategy = CnfStrategy.OPTIMAL): ClauseSet<String> {
+        var errorMsg: String
 
-        /**
-         * Parses a clause set or a propositional formula into a ClauseSet
-         * For format specifications, see ClauseSetParser and PropositionalParser
-         * @param formula formula or clause set to parse
-         * @return ClauseSet representing the input formula
-         */
-        fun parse(formula: String, strategy: CnfStrategy = CnfStrategy.OPTIMAL): ClauseSet<String> {
-            var errorMsg: String
+        val likelyFormula = (Regex(".*(&|\\||->|<=>).*", RegexOption.DOT_MATCHES_ALL) matches formula)
+        val likelyClauseSet = (Regex(".*(;|,).*", RegexOption.DOT_MATCHES_ALL) matches formula)
 
-            val likelyFormula = (Regex(".*(&|\\||->|<=>).*") matches formula)
-            val likelyClauseSet = (Regex(".*(;|,).*") matches formula)
+        // Try parsing as Dimacs-Like
+        try {
+            return DimacsLikeParser.parse(formula)
+        } catch (e: InvalidFormulaFormat) {} // We don't support this officially, so no custom error for invalid dimacs
 
-            // Try parsing as ClauseSet
-            try {
-                return ClauseSetParser.parse(formula)
-            } catch (e: InvalidFormulaFormat) {
-                errorMsg = "Parsing as clause set failed: ${e.message ?: "unknown error"}"
-            }
-
-            // Try parsing as PropositionalFormula
-            try {
-                return convertToCNF(PropositionalParser().parse(formula), strategy)
-            } catch (e: InvalidFormulaFormat) {
-
-                // If the input formula is likely intended to be certain input type, only report that error
-                if (likelyFormula && !likelyClauseSet)
-                    errorMsg = ""
-
-                if (likelyFormula || !likelyClauseSet)
-                    errorMsg += "\nParsing as propositional formula failed: ${e.message ?: "unknown error"}"
-
-                throw InvalidFormulaFormat(errorMsg)
-            }
+        // Try parsing as ClauseSet
+        try {
+            return ClauseSetParser.parse(formula)
+        } catch (e: InvalidFormulaFormat) {
+            errorMsg = "Parsing as clause set failed: ${e.message ?: "unknown error"}"
         }
 
-        /**
-         * Converts a propositional formula to a ClauseSet using a given conversion strategy
-         * Available strategies are:
-         *   NAIVE  : Conversion by conversion to negation normal form and expansion
-                      May result in exponential blowup, output formula is equivalent to input
-         *   TSEYTIN: Tseytin conversion, introduces new variables, output size is linear in terms
-                      of input size, output formula is equivalent in terms of satisfiability
-         *   OPTIMAL: Chooses among NAIVE or TSEYTIN based on which conversion results in the smaller
-                      formula
-         * @param formula formula to convert
-         * @param strategy conversion strategy to apply
-         * @return ClauseSet representation of the input formula
-         */
-        fun convertToCNF(formula: LogicNode, strategy: CnfStrategy): ClauseSet<String> {
-            var res: ClauseSet<String>
+        // Try parsing as PropositionalFormula
+        try {
+            return convertToCNF(PropositionalParser().parse(formula), strategy)
+        } catch (e: InvalidFormulaFormat) {
 
-            when (strategy) {
-                CnfStrategy.NAIVE -> res = NaiveCNF.transform(formula)
-                CnfStrategy.TSEYTIN -> res = TseytinCNF.transform(formula)
-                CnfStrategy.OPTIMAL -> {
-                    val tseytin = TseytinCNF.transform(formula)
-                    // Naive transformation might fail for large a large formula
-                    // Fall back to tseytin if so
-                    try {
-                        val naive = NaiveCNF.transform(formula)
-                        if (naive.clauses.size > tseytin.clauses.size)
-                            res = tseytin
-                        else
-                            res = naive
-                    } catch (e: FormulaConversionException) {
+            // If the input formula is likely intended to be certain input type, only report that error
+            if (likelyFormula && !likelyClauseSet)
+                errorMsg = ""
+
+            if (likelyFormula || !likelyClauseSet)
+                errorMsg += "\nParsing as propositional formula failed: ${e.message ?: "unknown error"}"
+
+            throw InvalidFormulaFormat(errorMsg)
+        }
+    }
+
+    /**
+     * Converts a propositional formula to a ClauseSet using a given conversion strategy
+     * Available strategies are:
+     *   NAIVE  : Conversion by conversion to negation normal form and expansion
+                  May result in exponential blowup, output formula is equivalent to input
+     *   TSEYTIN: Tseytin conversion, introduces new variables, output size is linear in terms
+                  of input size, output formula is equivalent in terms of satisfiability
+     *   OPTIMAL: Chooses among NAIVE or TSEYTIN based on which conversion results in the smaller
+                  formula
+     * @param formula formula to convert
+     * @param strategy conversion strategy to apply
+     * @return ClauseSet representation of the input formula
+     */
+    fun convertToCNF(formula: LogicNode, strategy: CnfStrategy): ClauseSet<String> {
+        var res: ClauseSet<String>
+
+        when (strategy) {
+            CnfStrategy.NAIVE -> res = NaiveCNF.transform(formula)
+            CnfStrategy.TSEYTIN -> res = TseytinCNF.transform(formula)
+            CnfStrategy.OPTIMAL -> {
+                val tseytin = TseytinCNF.transform(formula)
+                // Naive transformation might fail for large a large formula
+                // Fall back to tseytin if so
+                try {
+                    val naive = NaiveCNF.transform(formula)
+                    if (naive.clauses.size > tseytin.clauses.size)
                         res = tseytin
-                    }
+                    else
+                        res = naive
+                } catch (e: FormulaConversionException) {
+                    res = tseytin
                 }
             }
-
-            return res
         }
+
+        return res
     }
 }
 

--- a/backend/src/main/kotlin/kalkulierbar/tableaux/GenericTableaux.kt
+++ b/backend/src/main/kotlin/kalkulierbar/tableaux/GenericTableaux.kt
@@ -100,7 +100,7 @@ interface GenericTableauxState<AtomType> {
      * @param lemmaID Node to create lemma from
      * @return Atom representing the lemma node to be appended to the leaf
      */
-    @Suppress("ThrowsCount")
+    @Suppress("ThrowsCount", "ComplexMethod")
     fun getLemma(leafID: Int, lemmaID: Int): Atom<AtomType> {
         // Verify that subtree root for lemma creation exists
         if (lemmaID >= nodes.size || lemmaID < 0)

--- a/backend/src/main/kotlin/kalkulierbar/tableaux/RestrictionChecking.kt
+++ b/backend/src/main/kotlin/kalkulierbar/tableaux/RestrictionChecking.kt
@@ -12,7 +12,12 @@ import kalkulierbar.clause.Clause
  * @param clause Clause object to be used for expansion
  * @param applyPreprocessing Whether to simulate expansion clause preprocessing or not
  */
-fun <AtomType> verifyExpandRegularity(state: GenericTableauxState<AtomType>, leafID: Int, clause: Clause<AtomType>, applyPreprocessing: Boolean = true) {
+fun <AtomType> verifyExpandRegularity(
+    state: GenericTableauxState<AtomType>,
+    leafID: Int,
+    clause: Clause<AtomType>,
+    applyPreprocessing: Boolean = true
+) {
     // Create list of predecessor
     val leaf = state.nodes[leafID]
     val lst = mutableListOf(leaf.toAtom())

--- a/backend/src/test/kotlin/kalkulierbar/parsers/TestClauseSetParser.kt
+++ b/backend/src/test/kotlin/kalkulierbar/parsers/TestClauseSetParser.kt
@@ -24,10 +24,10 @@ class TestClauseSetParser {
 
     val validNonGeneric = listOf(
         Pair("a", "{a}"),
-        Pair("!a", "{!a}"),
+        Pair("-a", "{!a}"),
         Pair("a|b", "{a}, {b}"),
         Pair("a&b", "{a, b}"),
-        Pair("fUnkYvAR|!McVariable&thefirst", "{fUnkYvAR}, {!McVariable, thefirst}")
+        Pair("fUnkYvAR|-McVariable&thefirst", "{fUnkYvAR}, {!McVariable, thefirst}")
         )
 
     @Test
@@ -49,7 +49,7 @@ class TestClauseSetParser {
     @Test
     fun testValidNonGeneric() {
         for (tv: Pair<String, String> in validNonGeneric) {
-            assertEquals(tv.second, ClauseSetParser.parseGeneric(tv.first, "|", "&", "!").toString())
+            assertEquals(tv.second, ClauseSetParser.parseGeneric(tv.first, "|", "&", '-').toString())
         }
     }
 }

--- a/backend/src/test/kotlin/kalkulierbar/parsers/TestClauseSetParser.kt
+++ b/backend/src/test/kotlin/kalkulierbar/parsers/TestClauseSetParser.kt
@@ -49,7 +49,7 @@ class TestClauseSetParser {
     @Test
     fun testValidNonGeneric() {
         for (tv: Pair<String, String> in validNonGeneric) {
-            assertEquals(tv.second, ClauseSetParser.parseGeneric(tv.first, "|", "&").toString())
+            assertEquals(tv.second, ClauseSetParser.parseGeneric(tv.first, "|", "&", "!").toString())
         }
     }
 }

--- a/backend/src/test/kotlin/kalkulierbar/parsers/TestDimacsLikeParser.kt
+++ b/backend/src/test/kotlin/kalkulierbar/parsers/TestDimacsLikeParser.kt
@@ -1,0 +1,40 @@
+package kalkulierbar.tests.parsers
+
+import kalkulierbar.InvalidFormulaFormat
+import kalkulierbar.parsers.DimacsLikeParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TestDimacsLikeParser {
+
+    val invalidStrings = listOf("", " a", "0 a", "a b  0 c", "a b ", "a 0 0 b c 0 d", "--a", "a --b 0 c", "a -", "a 0 0")
+
+    val valid = listOf(
+        Pair("a", "{a}"),
+        Pair("-a", "{!a}"),
+        Pair("a 0 b", "{a}, {b}"),
+        Pair("a b", "{a, b}"),
+        Pair("a b 0 c", "{a, b}, {c}"),
+        Pair("a\n 0 b", "{a}, {b}"),
+        Pair("a 0 b 0", "{a}, {b}"),
+        Pair("fUnkYvAR 0 -McVariable thefirst", "{fUnkYvAR}, {!McVariable, thefirst}"),
+        Pair("1 -2 0 3", "{1, !2}, {3}")
+        )
+
+    @Test
+    fun testInvalidStrings() {
+        for (tv: String in invalidStrings) {
+            assertFailsWith<InvalidFormulaFormat> {
+                DimacsLikeParser.parse(tv)
+            }
+        }
+    }
+
+    @Test
+    fun testValidStrings() {
+        for (tv: Pair<String, String> in valid) {
+            assertEquals(tv.second, DimacsLikeParser.parse(tv.first).toString())
+        }
+    }
+}


### PR DESCRIPTION
- Allow numbers in clause-set notation
- Add dimacs-like clause set parser (maybe buggy?)
- Accept dimacs-like input in flexible clause set parser
- Fix input format detection for multi-line inputs
- Some tweaks from back in April that I don't remember